### PR TITLE
주요 배포 문서 확인

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "builds": [
     {
-      "src": "server.js",
+      "src": "railway-server.js",
       "use": "@vercel/node"
     },
     {
@@ -25,11 +25,16 @@
   "routes": [
     {
       "src": "/api/(.*)",
-      "dest": "/server.js"
+      "dest": "/railway-server.js"
     },
     {
       "src": "/(.*)",
       "dest": "/$1"
     }
-  ]
+  ],
+  "functions": {
+    "railway-server.js": {
+      "maxDuration": 30
+    }
+  }
 } 


### PR DESCRIPTION
Configure Vercel to use `railway-server.js` as the main server entry point and set a maximum function duration.